### PR TITLE
proper judo

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/Components/ArmbarredComponent.cs
+++ b/Content.Goobstation.Shared/MartialArts/Components/ArmbarredComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.MartialArts.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ArmbarredComponent : Component
+{
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public EntityUid Puller;
+}

--- a/Content.Goobstation.Shared/MartialArts/Events/JudoEvents.cs
+++ b/Content.Goobstation.Shared/MartialArts/Events/JudoEvents.cs
@@ -9,16 +9,21 @@
 using Robust.Shared.Serialization;
 
 namespace Content.Goobstation.Shared.MartialArts.Events;
+
 [Serializable, NetSerializable, DataDefinition]
-public sealed partial class JudoThrowPerformedEvent : EntityEventArgs;
+public sealed partial class JudoDiscombobulatePerformedEvent : EntityEventArgs;
 
 [Serializable, NetSerializable, DataDefinition]
 public sealed partial class JudoEyePokePerformedEvent : EntityEventArgs;
 
+[Serializable, NetSerializable, DataDefinition]
+public sealed partial class JudoThrowPerformedEvent : EntityEventArgs;
 
 [Serializable, NetSerializable, DataDefinition]
 public sealed partial class JudoArmbarPerformedEvent : EntityEventArgs;
 
+[Serializable, NetSerializable, DataDefinition]
+public sealed partial class JudoWheelThrowPerformedEvent : EntityEventArgs;
 
 [Serializable, NetSerializable, DataDefinition]
 public sealed partial class JudoGoldenBlastPerformedEvent : EntityEventArgs;

--- a/Content.Goobstation.Shared/MartialArts/MartialArtPrototype.cs
+++ b/Content.Goobstation.Shared/MartialArts/MartialArtPrototype.cs
@@ -9,7 +9,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Goobstation.Common.MartialArts;
-using Content.Goobstation.Shared.MartialArts.Components;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Prototypes;
 

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CQC.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CQC.cs
@@ -183,6 +183,7 @@ public partial class SharedMartialArtsSystem
             _pulling.TryStopPull(target, pullable, ent, true);
         _audio.PlayPvs(new SoundPathSpecifier("/Audio/Weapons/genhit3.ogg"), target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnCQCKick(Entity<CanPerformComboComponent> ent, ref CqcKickPerformedEvent args)
@@ -213,6 +214,7 @@ public partial class SharedMartialArtsSystem
         _grabThrowing.Throw(target, ent, dir, proto.ThrownSpeed);
         _audio.PlayPvs(new SoundPathSpecifier("/Audio/Weapons/genhit2.ogg"), target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnCQCRestrain(Entity<CanPerformComboComponent> ent, ref CqcRestrainPerformedEvent args)
@@ -224,6 +226,7 @@ public partial class SharedMartialArtsSystem
         _stun.TryKnockdown(target, TimeSpan.FromSeconds(proto.ParalyzeTime), true, proto.DropHeldItemsBehavior);
         _stamina.TakeStaminaDamage(target, proto.StaminaDamage, source: ent, applyResistances: true);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnCQCPressure(Entity<CanPerformComboComponent> ent, ref CqcPressurePerformedEvent args)
@@ -235,6 +238,7 @@ public partial class SharedMartialArtsSystem
         _stamina.TakeStaminaDamage(target, proto.StaminaDamage, source: ent, applyResistances: true);
 
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
 
         if (!_hands.TryGetActiveItem(target, out var activeItem))
             return;
@@ -257,6 +261,7 @@ public partial class SharedMartialArtsSystem
         _stamina.TakeStaminaDamage(target, proto.StaminaDamage, source: ent, applyResistances: true);
         _audio.PlayPvs(new SoundPathSpecifier("/Audio/Weapons/genhit1.ogg"), target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     #endregion

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CanPerformCombo.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CanPerformCombo.cs
@@ -118,7 +118,6 @@ public partial class SharedMartialArtsSystem
 
             RaiseLocalEvent(uid, beingPerformedEv);
             RaiseLocalEvent(uid, ev);
-            comp.LastAttacks.Clear();
         }
     }
     private void OnComboBeingPerformed(Entity<CanPerformComboComponent> ent, ref ComboBeingPerformedEvent args)

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs
@@ -84,6 +84,7 @@ public abstract partial class SharedMartialArtsSystem
         _status.TryRemoveStatusEffect(ent, "KnockedDown");
         _standingState.Stand(ent);
         _stamina.TryTakeStamina(ent, args.StaminaToHeal);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnSpinKick(Entity<CanPerformComboComponent> ent, ref SpinKickPerformedEvent args)
@@ -123,6 +124,7 @@ public abstract partial class SharedMartialArtsSystem
         }
 
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnSweepKick(Entity<CanPerformComboComponent> ent, ref SweepKickPerformedEvent args)
@@ -146,6 +148,7 @@ public abstract partial class SharedMartialArtsSystem
         _audio.PlayPvs(args.Sound, target);
         ApplyMultiplier(ent, args.AttackSpeedMultiplier, 0f, args.AttackSpeedMultiplierTime);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnCircleKick(Entity<CanPerformComboComponent> ent, ref CircleKickPerformedEvent args)
@@ -165,6 +168,7 @@ public abstract partial class SharedMartialArtsSystem
         DoDamage(ent, target, proto.DamageType, proto.ExtraDamage * power, out _, TargetBodyPart.Head);
         _audio.PlayPvs(args.Sound, target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnPushKick(Entity<CanPerformComboComponent> ent, ref PushKickPerformedEvent args)
@@ -195,6 +199,7 @@ public abstract partial class SharedMartialArtsSystem
         DoDamage(ent, target, proto.DamageType, proto.ExtraDamage * power, out _, TargetBodyPart.Torso);
         _grabThrowing.Throw(target, ent, dir.Normalized() * args.ThrowRange * power, proto.ThrownSpeed, behavior: proto.DropHeldItemsBehavior);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void ApplyMultiplier(EntityUid uid,

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.KungFuDragon.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.KungFuDragon.cs
@@ -64,6 +64,7 @@ public abstract partial class SharedMartialArtsSystem
         DoDamage(ent, target, proto.DamageType, proto.ExtraDamage, out _, TargetBodyPart.Torso);
         _audio.PlayPvs(args.Sound, target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnDragonTail(Entity<CanPerformComboComponent> ent, ref DragonTailPerformedEvent args)
@@ -86,6 +87,7 @@ public abstract partial class SharedMartialArtsSystem
 
         _audio.PlayPvs(args.Sound, target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
 
@@ -100,5 +102,6 @@ public abstract partial class SharedMartialArtsSystem
         DoDamage(ent, target, proto.DamageType, proto.ExtraDamage, out _, TargetBodyPart.Torso);
         _audio.PlayPvs(args.Sound, target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 }

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Ninjutsu.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Ninjutsu.cs
@@ -251,6 +251,7 @@ public abstract partial class SharedMartialArtsSystem
             TargetBodyPart.Torso);
         _audio.PlayPvs(args.Sound, target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnBiteTheDust(Entity<CanPerformComboComponent> ent, ref BiteTheDustPerformedEvent args)
@@ -277,6 +278,7 @@ public abstract partial class SharedMartialArtsSystem
             TargetBodyPart.Torso);
         _audio.PlayPvs(args.Sound, target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private float GetDamageMultiplier(EntityUid uid)

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.SleepingCarp.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.SleepingCarp.cs
@@ -142,6 +142,7 @@ public partial class SharedMartialArtsSystem
             var ev = new SleepingCarpSaying(saying);
             RaiseLocalEvent(ent, ev);
         }
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnSleepingCarpKneeHaul(Entity<CanPerformComboComponent> ent,
@@ -167,6 +168,7 @@ public partial class SharedMartialArtsSystem
             _pulling.TryStopPull(target, pullable, ent, true);
         _audio.PlayPvs(new SoundPathSpecifier("/Audio/Weapons/genhit3.ogg"), target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     private void OnSleepingCarpCrashingWaves(Entity<CanPerformComboComponent> ent,
@@ -186,6 +188,7 @@ public partial class SharedMartialArtsSystem
         _grabThrowing.Throw(target, ent, dir, proto.ThrownSpeed, damage);
         _audio.PlayPvs(new SoundPathSpecifier("/Audio/Weapons/genhit2.ogg"), target);
         ComboPopup(ent, target, proto.Name);
+        ent.Comp.LastAttacks.Clear();
     }
 
     #endregion

--- a/Resources/Prototypes/_Goobstation/MartialArts/judo.yml
+++ b/Resources/Prototypes/_Goobstation/MartialArts/judo.yml
@@ -52,9 +52,10 @@
   - Grab
   - Disarm
   event: !type:JudoThrowPerformedEvent
-  paralyzeTime: 4
+  paralyzeTime: 7
   staminaDamage: 15
   dropHeldItemsBehavior: NoDrop
+  canDoWhileProne: false
 
 - type: combo
   id: JudoArmbar
@@ -65,7 +66,7 @@
   - Disarm
   - Grab
   event: !type:JudoArmbarPerformedEvent
-  paralyzeTime: 3
+  paralyzeTime: 5
   staminaDamage: 25
   dropHeldItemsBehavior: AlwaysDrop
 

--- a/Resources/Prototypes/_Goobstation/MartialArts/judo.yml
+++ b/Resources/Prototypes/_Goobstation/MartialArts/judo.yml
@@ -18,8 +18,31 @@
   id: CorporateJudoMoves
   combos:
   - JudoThrow
-  - JudoEyepoke
   - JudoArmbar
+  - JudoDiscombobulate # Due to supercode this needs to be below Armbar, otherwise it takes priority
+  - JudoWheelThrow
+  - JudoEyePoke # Same here, must be below WheelThrow
+  #- JudoGoldenBlast
+
+- type: combo
+  id: JudoDiscombobulate
+  name: Discombobulate
+  martialArtsForm: CorporateJudo
+  attacks:
+  - Disarm
+  - Grab
+  event: !type:JudoDiscombobulatePerformedEvent
+  staminaDamage: 5
+
+- type: combo
+  id: JudoEyePoke
+  name: Eye Poke
+  martialArtsForm: CorporateJudo
+  attacks:
+  - Disarm
+  - Harm
+  event: !type:JudoEyePokePerformedEvent
+  extraDamage: 5
 
 - type: combo
   id: JudoThrow
@@ -29,10 +52,9 @@
   - Grab
   - Disarm
   event: !type:JudoThrowPerformedEvent
-  staminaDamage: 30
   paralyzeTime: 4
+  staminaDamage: 15
   dropHeldItemsBehavior: NoDrop
-  canDoWhileProne: false
 
 - type: combo
   id: JudoArmbar
@@ -43,14 +65,38 @@
   - Disarm
   - Grab
   event: !type:JudoArmbarPerformedEvent
-  staminaDamage: 70
+  paralyzeTime: 3
+  staminaDamage: 25
+  dropHeldItemsBehavior: AlwaysDrop
 
 - type: combo
-  id: JudoEyepoke
-  name: Eyepoke
+  id: JudoWheelThrow
+  name: Wheel Throw
   martialArtsForm: CorporateJudo
   attacks:
+  - Grab
   - Disarm
   - Harm
-  event: !type:JudoEyePokePerformedEvent
-  extraDamage: 5
+  event: !type:JudoWheelThrowPerformedEvent
+  staminaDamage: 65 # 65 real
+
+# Conflicts with armbar + hugs don't seem to count?, to be implemented later
+#- type: combo
+#  id: JudoGoldenBlast
+#  name: Golden Blast
+#  martialArtsForm: CorporateJudo
+#  attacks:
+#  - Hug
+#  - Disarm
+#  - Hug
+#  - Grab
+#  - Disarm
+#  - Disarm
+#  - Grab
+#  - Hug
+#  - Disarm
+#  - Disarm
+#  - Grab
+#  - Hug
+#  event: !type:JudoGoldenBlastPerformedEvent
+#  paralyzeTime: 30

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
@@ -16,7 +16,7 @@
 
   ## Special abilities
 
-  CQC users are better at Disarm intent, as their shoves will always deal extra stamina damage to the opponent.
+  CQC users are better at Disarm intent, as their shoves will deal extra stamina damage to the opponent.
 
   ### Precise Parrying
 

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/Capoeira.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/Capoeira.xml
@@ -27,7 +27,7 @@
 
   ### Capoeira Tempo
 
-  Hit or miss, it's just part of the dance!  And the best part is about to start!
+  Hit or miss, it's just part of the dance! And the best part is about to start!
 
   A missed attack sharpens the next, reducing its recovery and increasing the damage.
 

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CorporateJudo.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CorporateJudo.xml
@@ -21,6 +21,15 @@
 
   ## Combo attacks
 
+  ### Discombobulate
+
+  <Box>
+    <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
+    <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
+  </Box>
+
+  Slows the opponent down and deals some Stamina damage.
+
   ### Eye Poke
 
   <Box>
@@ -37,7 +46,7 @@
     <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
   </Box>
 
-  Only works on standing opponents, dealing Stamina damage, knocking then down and disarming them.
+  Only works on standing opponents, dealing Stamina damage and knocking them down.
 
   ### Armbar
 
@@ -47,6 +56,18 @@
     <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
   </Box>
 
-  If the opponent is downed, inflicts Stamina damage, otherwise disarms them.
+  Only works on downed opponents. Inflicts Stamina damage and locks the opponent in a choke grab.
+  If performed while standing, further knocks the opponent down and disarms them.
+
+  ### Wheel Throw
+
+  <Box>
+    <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
+    <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
+    <GuideEntityEmbed Entity="GuidebookHarm" Caption=""/>
+  </Box>
+
+  Only works on downed opponents locked in a choke grab.
+  Flips the opponent over the shoulder, inflicting massive Stamina damage.
 
 </Document>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CorporateJudo.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CorporateJudo.xml
@@ -46,7 +46,8 @@
     <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
   </Box>
 
-  Only works on standing opponents, dealing Stamina damage and knocking them down.
+  Can only be perfomed while standing. Only works on standing opponents, dealing Stamina damage and knocking them down.
+  Knockdown duration is affected by their Stamina resistance.
 
   ### Armbar
 
@@ -56,8 +57,8 @@
     <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
   </Box>
 
-  Only works on downed opponents. Inflicts Stamina damage and locks the opponent in a choke grab.
-  If performed while standing, further knocks the opponent down and disarms them.
+  Only works on downed opponents. Inflicts Stamina damage, disarms them, and locks them in an armbar until they manage to stand up.
+  Armbar works similarly to a knockdown and choke grab, and its duration is affected by their Stamina resistance.
 
   ### Wheel Throw
 
@@ -67,7 +68,7 @@
     <GuideEntityEmbed Entity="GuidebookHarm" Caption=""/>
   </Box>
 
-  Only works on downed opponents locked in a choke grab.
-  Flips the opponent over the shoulder, inflicting massive Stamina damage.
+  Only works on opponents locked in an armbar. Flips the opponent over the shoulder,
+  inflicting massive Stamina damage, and forces the user back on their feet.
 
 </Document>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/MartialArts.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/MartialArts.xml
@@ -56,7 +56,7 @@
   To perform disarm, press [bold] Right Mouse Button [/bold] with [color=Red] Harm Mode [/color] turned ON.
 
   If you are unarmed, you will try to shove at the place of your cursor. Shoving will push affected characters,
-  and has some chance to deal some [color=Cyan] Stamina [/color] damage and knock an item out of the opponent's hands.
+  dealing some [color=Cyan] Stamina [/color] damage, and it has a chance to knock an item out of the opponent's hands.
   If you are armed with a melee weapon, you will swing it, attacking everyone you hit and taking some stamina damage yourself.
   Swinging a weapon is not a real "Disarm", and does not count as a successful Disarm action for combo purposes.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
нормальное дзюдо с киданием через плечо вместо перебафанного армбара
и еще микроправки гайдбука
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Martial Art combos now contain ent.Comp.LastAttacks.Clear() instead of it being in the CheckCombo method, so failed combos don't clear the list.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
